### PR TITLE
Checkstyle legacy coders support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,8 +12,15 @@ script:
 - java -cp environment/target/tygronenv-*-jar-with-dependencies.jar login.Login $email $password
 # test the code
 - mvn test -Dcobertura.skip
+# get the latest commit of legacy contributers on branch
+# take the latest commit of the legacy contributors
+# that have done work on commits of the current branch and put this in
+# a text file with the UTC date and the commit hash
+- while read name;do echo $(git log --author="$(echo $name | sed 's/\\r//g')" upstream/context..HEAD --format="%ct %H" | head -1) >> latestcommits.txt ; done < legacycoders.cfg
+# take the latest commit and get the second value, which is the commit hash
+# this commit hash is put in the variable TAIL, we use a python script to get_second_entry the second value of the space separeted string, then
 # test checkstyle only on changed lines using this python script
-- git diff upstream/context...HEAD -U0 -- *.java --minimal | java -jar jython-standalone-2.7.0.jar checkstylediff.py
+- git diff $(java -jar jython-standalone-2.7.0.jar get_second_entry.py $(sort latestcommits.txt -r | head -1))...HEAD -U0 -- *.java --minimal | java -jar jython-standalone-2.7.0.jar checkstylediff.py
 # checkstyle check is configured with these arguments
 - mvn checkstyle:check -Dcheckstyle.config.location="$PWD/sun_checks_custom.xml" -Dcheckstyle.suppressions.location="$PWD/suppressions.xml" -Dcheckstyle.suppressions.file.expression=checkstyle.supression.file
 #check pmd and checkstyle only for environment

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,15 +12,11 @@ script:
 - java -cp environment/target/tygronenv-*-jar-with-dependencies.jar login.Login $email $password
 # test the code
 - mvn test -Dcobertura.skip
+# test checkstyle only on changed lines using this python script
 # get the latest commit of legacy contributers on branch
 # take the latest commit of the legacy contributors
-# that have done work on commits of the current branch and put this in
-# a text file with the UTC date and the commit hash
-- while read name;do echo $(git log --author="$(echo $name | sed 's/\\r//g')" upstream/context..HEAD --format="%ct %H" | head -1) >> latestcommits.txt ; done < legacycoders.cfg
-# take the latest commit and get the second value, which is the commit hash
-# this commit hash is put in the variable TAIL, we use a python script to get_second_entry the second value of the space separeted string, then
-# test checkstyle only on changed lines using this python script
-- git diff $(java -jar jython-standalone-2.7.0.jar get_second_entry.py $(sort latestcommits.txt -r | head -1))...HEAD -U0 -- *.java --minimal | java -jar jython-standalone-2.7.0.jar checkstylediff.py
+# that have done work on commits of the current branch
+- git diff $(git log upstream/context..HEAD --format="%cn %H" | java -jar jython-standalone-2.7.0.jar get_last_legacy_commit.py)...HEAD -U0 -- *.java --minimal | java -jar jython-standalone-2.7.0.jar checkstylediff.py
 # checkstyle check is configured with these arguments
 - mvn checkstyle:check -Dcheckstyle.config.location="$TRAVIS_BUILD_DIR/sun_checks_custom.xml" -Dcheckstyle.suppressions.location="$TRAVIS_BUILD_DIR/suppressions.xml" -Dcheckstyle.suppressions.file.expression=checkstyle.suppression.file
 #check pmd and checkstyle only for environment

--- a/get_last_legacy_commit.py
+++ b/get_last_legacy_commit.py
@@ -1,0 +1,33 @@
+# Levi van Aanholt 2016
+# Rudimentary script that takes piped input list as <commitauthor> <commithash> for the commits
+# of a develop/feature branch compared to a branch to merge to and finds the first and therefore latest commit 
+# on the develop/feature branch that has been made by a legacy coder.
+
+import sys
+import re
+import subprocess
+
+LEGACY_CODERS_CONFIG_FILE = "legacycoders.cfg"
+BRANCH_TO_MERGE_TO = "upstream/context"
+
+legacy_coders = []
+with open(LEGACY_CODERS_CONFIG_FILE) as f:
+	legacy_coders = f.readlines()
+
+latest_legacy_commit = subprocess.Popen("git rev-parse "+BRANCH_TO_MERGE_TO, stdout=subprocess.PIPE).stdout.read().replace("\n","")
+legacy_coder_found = False
+
+for line in sys.stdin:
+	
+	for coder in legacy_coders:
+		coder = coder.replace("\n","")
+		if re.findall(coder+"\s", line):
+			latest_legacy_commit = line.replace(coder+" ","")
+			legacy_coder_found = True
+			break
+	
+	if legacy_coder_found:
+		break
+
+print(latest_legacy_commit)
+	

--- a/get_second_entry.py
+++ b/get_second_entry.py
@@ -1,0 +1,5 @@
+# rudimentary program to get the second
+# value of a spaces seperated file
+
+import sys
+print(sys.argv[2])

--- a/legacycoders.cfg
+++ b/legacycoders.cfg
@@ -1,0 +1,2 @@
+Wouter1
+Frank


### PR DESCRIPTION
Code that does not adhere to our checkstyle rules is still
being developed while we develop code that must adhere to checkstyle
rules.
The situation came up where conflicts needed to be resolved of
new "legacy" code but because they are changes compared to the context
branch they were still deemed as needing proper checkstyling.

The commit log diff from feature branch
compared to the context branch is taken and the latest commit is
chosen to through list order that is from a legacy contributor.
